### PR TITLE
Remove version from editor storage path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [0.1.0]
-### Changed
+### Removed
 - editor version parameter from `Grid::EditorIntegration::Storages::AbstractStorage` initialization
 - editor version parameter from `create_storage` and `create_from_global_settings` methods of `Grid::EditorIntegration::Storages::Factory`
 - editor version from editor files urls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [0.1.0]
+### Changed
+- editor version parameter from `Grid::EditorIntegration::Storages::AbstractStorage` initialization
+- editor version parameter from `create_storage` and `create_from_global_settings` methods of `Grid::EditorIntegration::Storages::Factory`
+- editor version from editor files urls
+
+    You need to redownload editor files by `RAILS_ENV=production bundle exec rake grid:editor_integration:download_editor`

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,9 @@ gemspec
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
+
+
+group :test do
+  gem "webmock", require: false
+  gem "simplecov", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grid-editor-integration (0.0.11)
+    grid-editor-integration (0.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,16 +41,22 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (6.0.3)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     builder (3.2.2)
     concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    docile (1.3.1)
     erubis (2.7.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashdiff (0.3.7)
     i18n (0.7.0)
     json (1.8.3)
     loofah (2.0.3)
@@ -66,6 +72,7 @@ GEM
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     pkg-config (1.1.7)
+    public_suffix (3.0.3)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -115,6 +122,12 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    safe_yaml (1.0.4)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sprockets (3.6.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -126,6 +139,10 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -136,6 +153,8 @@ DEPENDENCIES
   rails
   rspec
   rspec-rails
+  simplecov
+  webmock
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/app/helpers/grid/editor_integration/application_helper.rb
+++ b/app/helpers/grid/editor_integration/application_helper.rb
@@ -22,11 +22,10 @@ module Grid
         "#{storage.file_url(file_name)}?_dc=#{Grid::EditorIntegration::Utils.read_version}"
       end
 
-      def storage(version = '1')
+      def storage
         @storage ||= Grid::EditorIntegration::Storages::Factory.create_storage(
           Grid::EditorIntegration.storage,
           Grid::EditorIntegration.path,
-          version,
           Grid::EditorIntegration.cdn_url,
           Grid::EditorIntegration.options_for_storage)
       end

--- a/lib/grid/editor_integration/downloader.rb
+++ b/lib/grid/editor_integration/downloader.rb
@@ -9,7 +9,6 @@ module Grid
         @storage = Grid::EditorIntegration::Storages::Factory.create_storage(
           Grid::EditorIntegration.storage,
           Grid::EditorIntegration.path,
-          get_major_version(config["content_editor_version"]),
           Grid::EditorIntegration.cdn_url,
           Grid::EditorIntegration.options_for_storage)
 
@@ -64,15 +63,6 @@ module Grid
               content_type: Grid::EditorIntegration::CONTENT_TYPES[item["filetype"]]
             }
           }
-        end
-
-        def get_major_version(version)
-          if version
-            v = version.split(".").first.to_i
-            version[/^(\d[.]){2}\d/] ? v : 1
-          else
-            1
-          end
         end
 
         def download_files(urls)

--- a/lib/grid/editor_integration/storages/abstract.rb
+++ b/lib/grid/editor_integration/storages/abstract.rb
@@ -2,11 +2,10 @@ module Grid
   module EditorIntegration
     module Storages
       class AbstractStorage
-        attr_accessor :path, :version, :cdn_url
+        attr_accessor :path, :cdn_url
 
-        def initialize(path = nil, version = nil, cdn_url = "", options = {})
-          self.path = path
-          self.version = version
+        def initialize(path = nil, cdn_url = "", options = {})
+          self.path = options[:prefix] ? ::File.join(options[:prefix], path) : path
           self.cdn_url = cdn_url
         end
 
@@ -16,13 +15,11 @@ module Grid
 
         def create_path() raise NotImplementedError; end
 
-        def create_versioned_path() raise NotImplementedError; end
-
         def save_content_in_file(content, file_name, options = {})
           raise NotImplementedError
         end
-        
-        def file_url(file_name) "#{cdn_url}/#{path}/#{version}/#{file_name}"; end
+
+        def file_url(file_name) "#{cdn_url}/#{path}/#{file_name}"; end
 
         def get_content_by_file_name(file_name) raise NotImplementedError; end
 

--- a/lib/grid/editor_integration/storages/factory.rb
+++ b/lib/grid/editor_integration/storages/factory.rb
@@ -5,18 +5,16 @@ module Grid
   module EditorIntegration
     module Storages
       class Factory
-        def self.create_storage(name, path = nil, version = nil,
-          cdn_url = "", options = {})
+        def self.create_storage(name, path = nil, cdn_url = "", options = {})
 
           "Grid::EditorIntegration::Storages::#{name.capitalize}".
-            constantize.new(path, version, cdn_url, options)
+            constantize.new(path, cdn_url, options)
         end
 
-        def self.create_from_global_settings(version)
+        def self.create_from_global_settings
           create_storage(
             Grid::EditorIntegration.storage,
             Grid::EditorIntegration.path,
-            version,
             Grid::EditorIntegration.cdn_url,
             Grid::EditorIntegration.options_for_storage)
         end

--- a/lib/grid/editor_integration/storages/file.rb
+++ b/lib/grid/editor_integration/storages/file.rb
@@ -7,7 +7,7 @@ module Grid
       class File < AbstractStorage
         attr_reader :storage_path
 
-        def initialize(path = nil, version = nil, cdn_url = "", options = {})
+        def initialize(path = nil, cdn_url = "", options = {})
           super
 
           @storage_path = options[:path]
@@ -16,7 +16,7 @@ module Grid
         def save_content_in_file(current_content, file_name, options = {})
           full_file_name = full_local_file_name(file_name)
           create_path_for_file(full_file_name)
-          f = ::File.new(full_file_name, 'wb')
+          f = ::File.new(full_file_name, "wb")
           f.write(current_content)
           f.close
         end
@@ -26,25 +26,27 @@ module Grid
         def path_exists?(path) Dir.exists? path; end
 
         def create_path_for_file(path)
-          create_path(path.split('/')[0..-2].join('/'))
+          create_path(path.split("/")[0..-2].join("/"))
         end
 
         def create_path(path)
-          path[1..-1].split('/').inject('/') do |current_path, folder_name|
-            current_path += folder_name + '/'
+          path[1..-1].split("/").inject("/") do |current_path, folder_name|
+            current_path += folder_name + "/"
             ::Dir.mkdir(current_path) unless path_exists? current_path
             current_path
           end
         end
 
-        def full_local_file_name(file_name) "#{versioned_path}/#{file_name}"; end
+        def local_path
+          ::File.join(storage_path, path)
+        end
 
-        def create_versioned_path() create_path(versioned_path); end
+        def full_local_file_name(file_name)
+          ::File.join(local_path, file_name)
+        end
 
-        def versioned_path() "#{storage_path}/#{path}/#{version}"; end
-        
-        def clear()
-          FileUtils.rm_dir(versioned_path, true) if path_exists?(versioned_path)
+        def clear
+          FileUtils.rm_r(local_path, force: true) if path_exists?(local_path)
         end
 
         def get_content_by_file_name(file_name)

--- a/lib/grid/editor_integration/storages/s3.rb
+++ b/lib/grid/editor_integration/storages/s3.rb
@@ -1,5 +1,5 @@
 require "grid/editor_integration/storages/abstract"
-require 'aws-sdk-v1'
+require "aws-sdk-v1"
 
 module Grid
   module EditorIntegration
@@ -8,7 +8,7 @@ module Grid
         attr_accessor :bucket, :content_encoding
         attr_reader :storage
 
-        def initialize(path = nil, version = nil, cdn_url = "", options = {})
+        def initialize(path = nil, cdn_url = "", options = {})
           super
 
           self.bucket = options[:bucket]
@@ -28,7 +28,9 @@ module Grid
             content_type: options[:content_type])
         end
 
-        def full_file_name(file_name) "#{path}/#{version}/#{file_name}"; end
+        def full_file_name(file_name)
+          ::File.join(path, file_name)
+        end
 
         def get_content_by_file_name(file_name)
           res = storage.
@@ -41,7 +43,7 @@ module Grid
         def clear
           storage.buckets[bucket].
             objects.
-            with_prefix("#{path}/#{version}").
+            with_prefix(path).
             each { |o| o.delete }
         end
       end

--- a/lib/grid/editor_integration/utils.rb
+++ b/lib/grid/editor_integration/utils.rb
@@ -37,8 +37,8 @@ module Grid
         update_version
       end
 
-      def self.clear(version)
-        storage = Grid::EditorIntegration::Storages::Factory.create_from_global_settings(version)
+      def self.clear
+        storage = Grid::EditorIntegration::Storages::Factory.create_from_global_settings
         storage.clear
       end
 

--- a/lib/grid/editor_integration/version.rb
+++ b/lib/grid/editor_integration/version.rb
@@ -1,5 +1,5 @@
 module Grid
   module EditorIntegration
-    VERSION = "0.0.11"
+    VERSION = "0.1.0"
   end
 end

--- a/spec/requests/push_spec.rb
+++ b/spec/requests/push_spec.rb
@@ -1,15 +1,10 @@
 require 'spec_helper'
 
 describe Grid::EditorIntegration::EditorConfig, type: :request do
-  context 'update from configurator' do
-    let(:editor_url) do
-      '/grid_editor_integration/update_editor_config'
-    end
-
-    it 'push request should update editor on good request' do
-      post editor_url,
-      {
+  let(:editor_config) {
+    {
         "token" => Grid::EditorIntegration.token,
+        "content_editor_version" => "1",
         "data" => {
           "plugins" => [ {
             "url" => "https://ceditor.setka.io/public.js",
@@ -35,6 +30,23 @@ describe Grid::EditorIntegration::EditorConfig, type: :request do
           } ]
         }
       }
+  }
+
+  context 'update from configurator', file_storage: true do
+    before(:each) do
+      stub_request(:get, "https://ceditor.setka.io/public.js").and_return(status: 200, body: "")
+      stub_request(:get, "https://ceditor.setka.io/theme.min.css").and_return(status: 200, body: "")
+      stub_request(:get, "https://ceditor.setka.io/theme.json").and_return(status: 200, body: "")
+      stub_request(:get, "https://ceditor.setka.io/editor.min.css").and_return(status: 200, body: "")
+      stub_request(:get, "https://ceditor.setka.io/editor.min.js").and_return(status: 200, body: "")
+    end
+
+    let(:editor_url) do
+      '/grid_editor_integration/update_editor_config'
+    end
+
+    it 'push request should update editor on good request' do
+      post editor_url, editor_config
       expect(response.status).to eq(200)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,11 @@
+require 'simplecov'
+SimpleCov.start
+
 ENV['RAILS_ENV'] ||= 'test'
 
 require File.expand_path("../test_app/config/environment.rb", __FILE__)
 require 'rspec/rails'
+require 'webmock/rspec'
 
 Rails.backtrace_cleaner.remove_silencers!
 
@@ -10,4 +14,36 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
+
+  config.before(:example, file_storage: true) do
+    Grid::EditorIntegration.cdn_url = ""
+    Grid::EditorIntegration.storage = "file"
+    Grid::EditorIntegration.options_for_storage = {
+      prefix: ENV['CI_JOB_ID'],
+      path: "#{Dir.pwd}/spec/test_app/public/"
+    }
+  end
+
+  config.before(:example, aws_storage: true) do
+    WebMock.disable_net_connect!(allow: %r{rgw.lookatmedia.ru})
+
+    unless ENV['AWS_ENDPOINT']
+      skip "Set S3 storage params to test this feature"
+    end
+
+    Grid::EditorIntegration.cdn_url = "#{ENV['AWS_PROTOCOL']}://#{ENV['AWS_ENDPOINT']}/#{ENV['AWS_BUCKET']}"
+    Grid::EditorIntegration.storage = "s3"
+    Grid::EditorIntegration.options_for_storage = {
+      prefix: ENV['CI_JOB_ID'],
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      use_ssl: false,
+      s3_protocol: ENV['AWS_PROTOCOL'],
+      s3_endpoint: ENV['AWS_ENDPOINT'],
+      s3_region: ENV['AWS_REGION'],
+      s3_force_path_style: true,
+      bucket: ENV['AWS_BUCKET'],
+      content_encoding: 'gzip'
+    }
+  end
 end


### PR DESCRIPTION
Instead of using default version (`1`)  gem use editor files provided by `https://editor.setka.io/api/v1/custom/builds/current` 

also fix specs